### PR TITLE
Corrigir persistência do ID da "InitialSystemMessage"

### DIFF
--- a/chatservice/internal/infra/repository/chat.go
+++ b/chatservice/internal/infra/repository/chat.go
@@ -28,7 +28,7 @@ func (r *ChatRepositoryMySQL) CreateChat(ctx context.Context, chat *entity.Chat)
 		db.CreateChatParams{
 			ID:               chat.ID,
 			UserID:           chat.UserID,
-			InitialMessageID: chat.InitialSystemMessage.Content,
+			InitialMessageID: chat.InitialSystemMessage.ID,
 			Status:           chat.Status,
 			TokenUsage:       int32(chat.TokenUsage),
 			Model:            chat.Config.Model.Name,
@@ -128,6 +128,7 @@ func (r *ChatRepositoryMySQL) SaveChat(ctx context.Context, chat *entity.Chat) e
 		ID:               chat.ID,
 		UserID:           chat.UserID,
 		Status:           chat.Status,
+		InitialMessageID: chat.InitialSystemMessage.ID,
 		TokenUsage:       int32(chat.TokenUsage),
 		Model:            chat.Config.Model.Name,
 		ModelMaxTokens:   int32(chat.Config.Model.MaxTokens),


### PR DESCRIPTION
Após realizar alguns testes, encontrei um problema no método `CreateChat` que estava criando um novo chat utilizando o conteúdo da mensagem inicial como ID. Além disso, verifiquei que no método `SaveChat` não estava sendo passado o ID da mensagem inicial, o que apagava o registro no banco. Para solucionar este problema, fiz as seguintes alterações:

- No método` CreateChat`, utilizei um novo ID gerado automaticamente para o chat criado;
- No método `SaveChat`, incluí o ID da mensagem inicial para que seja armazenado corretamente.